### PR TITLE
changed update file tag to main

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-files:
-    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@1.0.0
+    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@main
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module "elb" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
 
 ## Modules

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -23,7 +23,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 


### PR DESCRIPTION
This PR changes update workflow tag to main.
This will ensure only the recent workflow is will run.
It also ensures no manual changes will be done to the update file in case there is an update to the reusable workflow.